### PR TITLE
Add Savannah's GNU and non-GNU sites to the repositories

### DIFF
--- a/sites/forums_qa.txt
+++ b/sites/forums_qa.txt
@@ -8,3 +8,5 @@ https://lobste.rs/
 https://coderwall.com
 https://grokbase.com
 https://mail.openjdk.java.net
+https://lists.gnu.org
+https://lists.nongnu.org

--- a/sites/repositories.txt
+++ b/sites/repositories.txt
@@ -2,3 +2,5 @@ https://github.com
 https://gitlab.com
 https://sourceforge.net
 https://sr.ht
+https://savannah.gnu.org
+https://savannah.nongnu.org


### PR DESCRIPTION
Savannah is a bit old-school, but it's still used.

(The README says to open issues for new sites. Using PRs seems like it would be less work for everyone involved? Hope it's ok.)