### PR TITLE
Add first draft Common Lisp entry

### DIFF
--- a/cards/cards.yml
+++ b/cards/cards.yml
@@ -46,3 +46,13 @@
     "Tutorial": https://nim-lang.org/docs/tut1.html
     "Playground": https://play.nim-lang.org
     "Forum": https://forum.nim-lang.org/
+
+"lisp common\ lisp cl":
+  name: "Common Lisp"
+  description: "Common Lisp is the ANSI-standardized programmable programming language. It emphasizes incremental and bottom-up software development. As a Lisp, CL comes from a line of languages going back as far as John McCarthy's original 1958 version."
+  links:
+    "HyperSpec": http://www.lispworks.com/documentation/HyperSpec/Front/
+    "Learn in Y Minutes": https://learnxinyminutes.com/docs/common-lisp/
+    "CLiki": https://www.cliki.net/
+    "Quickdocs": http://quickdocs.org/
+


### PR DESCRIPTION
I added a literal space to make "Common Lisp" its own search term, which may be wrong for your system. If so, you can change that. 