### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ There are 5 categories of search on Quickref.dev. Each corresponds to a .txt-fil
 - Blogs (`blogs.txt`)
 - Repositories (`repositories.txt`)
 
-Category "All" is compiled automatically by combining all other categories. Quickref.dev searches in all subdomains. For example, if `https://abc.com` is specified, any subdomain of arbitrary depth (`https://x.abc.com`, `https://y.x.abc.com`, etc) are indexed and searched.
+Category "All" is compiled automatically by combining all other categories. Quickref.dev searches in all subdomains, regardless of depth. For example, if `https://abc.com` is specified, all existing subdomains (`https://x.abc.com`, `https://y.x.abc.com`, etc) are indexed and searched.
 
 ## Cards
 


### PR DESCRIPTION
I think the sentence "For example, if `https://abc.com` is specified, any subdomain of arbitrary depth (`https://x.abc.com`, `https://y.x.abc.com`, etc) are indexed and searched." could use improvement. "Any subdomain of arbitrary depth" to me implies a restriction of subdomains to only those that are of arbitrary depth (which is meant to be interpreted as the depth does not matter). "Any subdomain of any depth" or "any subdomain, regardless of depth" would be better. Also, "subdomain" is singular but "are" is used. (any subdomain are indexed and searched).

I think a good solution to this sentence is to separate the explanation from the examples.