### PR TITLE
Add readthedocs to python documentation sites

### DIFF
--- a/sites/docs.txt
+++ b/sites/docs.txt
@@ -6,6 +6,7 @@ https://tensorflow.org
 https://pandas.pydata.org
 https://pytorch.org
 http://palletsprojects.com
+https://readthedocs.org
 
 # JavaScript & JS VM
 https://v8.dev


### PR DESCRIPTION
readthedocs.org is hosting documentations for a lot of python packages and I think it makes sense to include it here